### PR TITLE
Feat: AST Conversion

### DIFF
--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -19,19 +19,6 @@ impl From<Term> for MathExpr {
         MathExpr::Term(value)
     }
 }
-trait MathExprOperation {
-    fn as_addition(self) -> MathExpr;
-    fn as_subtraction(self) -> MathExpr;
-}
-impl MathExprOperation for (Box<MathExpr>, Term) {
-    fn as_addition(self) -> MathExpr {
-        MathExpr::Add(self.0, self.1)
-    }
-
-    fn as_subtraction(self) -> MathExpr {
-        MathExpr::Subtract(self.0, self.1)
-    }
-}
 
 #[derive(PartialEq, Debug)]
 pub enum Term {
@@ -43,21 +30,6 @@ pub enum Term {
 impl From<Factor> for Term {
     fn from(value: Factor) -> Self {
         Self::Factor(value)
-    }
-}
-
-trait TermOperation {
-    fn as_multiplication(self) -> Term;
-    fn as_division(self) -> Term;
-}
-
-impl TermOperation for (Box<Term>, Factor) {
-    fn as_multiplication(self) -> Term {
-        Term::Multiply(self.0, self.1)
-    }
-
-    fn as_division(self) -> Term {
-        Term::Divide(self.0, self.1)
     }
 }
 

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -14,11 +14,51 @@ pub enum MathExpr {
     Subtract(Box<MathExpr>, Term),
 }
 
+impl From<Term> for MathExpr {
+    fn from(value: Term) -> Self {
+        MathExpr::Term(value)
+    }
+}
+trait MathExprOperation {
+    fn as_addition(self) -> MathExpr;
+    fn as_subtraction(self) -> MathExpr;
+}
+impl MathExprOperation for (Box<MathExpr>, Term) {
+    fn as_addition(self) -> MathExpr {
+        MathExpr::Add(self.0, self.1)
+    }
+
+    fn as_subtraction(self) -> MathExpr {
+        MathExpr::Subtract(self.0, self.1)
+    }
+}
+
 #[derive(PartialEq, Debug)]
 pub enum Term {
     Factor(Factor),
     Multiply(Box<Term>, Factor),
     Divide(Box<Term>, Factor),
+}
+
+impl From<Factor> for Term {
+    fn from(value: Factor) -> Self {
+        Self::Factor(value)
+    }
+}
+
+trait TermOperation {
+    fn as_multiplication(self) -> Term;
+    fn as_division(self) -> Term;
+}
+
+impl TermOperation for (Box<Term>, Factor) {
+    fn as_multiplication(self) -> Term {
+        Term::Multiply(self.0, self.1)
+    }
+
+    fn as_division(self) -> Term {
+        Term::Divide(self.0, self.1)
+    }
 }
 
 #[derive(PartialEq, Debug)]
@@ -37,6 +77,28 @@ pub enum Factor {
     },
     Abs(Box<MathExpr>),
 }
+
+impl From<f64> for Factor {
+    fn from(value: f64) -> Self {
+        Factor::Constant(value)
+    }
+}
+impl From<Box<MathExpr>> for Factor {
+    fn from(value: Box<MathExpr>) -> Self {
+        Factor::Expression(value)
+    }
+}
+impl From<MathIdentifier> for Factor {
+    fn from(value: MathIdentifier) -> Self {
+        Factor::Variable(value)
+    }
+}
+impl From<FunctionCall> for Factor {
+    fn from(value: FunctionCall) -> Self {
+        Factor::FunctionCall(value)
+    }
+}
+
 
 /// A mathematical identifier, for example variable or function names.
 ///

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -227,6 +227,17 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn constant() {
+        parse_test(
+            "1",
+            Ast {
+                root_expr: MathExpr::Term(Term::Factor(Factor::Constant(1.0))),
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
     async fn addition() {
         parse_test(
             "1+2+3",

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -367,18 +367,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn implicit_multiplication_command() {
+    async fn implicit_multiplication() {
         parse_test(
-            "2\\pi",
+            "\\pi(x)\\ln(x)",
             Ast {
-                root_expr: MathExpr::Term(Term::Multiply(
-                    // 2
-                    Box::new(Term::Factor(Factor::Constant(2.0))),
-                    // \pi
-                    Factor::Variable(MathIdentifier {
-                        tokens: vec![Token::Backslash, Token::Identifier("pi".to_string())],
-                    }),
-                )),
+                root_expr: MathExpr::Term(Term::Factor(Factor::Variable(MathIdentifier {
+                    tokens: vec![Token::Backslash, Token::Identifier("pi".to_string())],
+                }))),
             },
         )
         .await;


### PR DESCRIPTION
# Ast Conversion using traits

## Traits implemented:
_T is generic and has many implementation details within the code_
- From\<T\>

## Enum values without trait implementation:
- Factor::Exponent
- Factor::Root
- Factor::Abs
- MathExpr::Add
- MathExpr::Subtract
- Term::Multiply
- Term::Divide