### PR TITLE
Implement token replacement in TokenReader to implement implicit multiplication within one identifier token

### DIFF
--- a/parser/src/evaluator.rs
+++ b/parser/src/evaluator.rs
@@ -1,8 +1,5 @@
 /// A simple single-threaded evaluator for an AST.
-use crate::{
-    ast::{Ast, Factor, MathExpr, Term},
-    token::Token,
-};
+use crate::ast::{Ast, Factor, MathExpr, Term};
 
 impl Ast {
     pub fn eval(&self) -> f64 {
@@ -35,15 +32,7 @@ impl Factor {
         match self {
             Factor::Constant(c) => *c,
             Factor::Expression(expr) => expr.eval(),
-            Factor::Variable(var) => match &var.tokens[..] {
-                // TODO use MathContext to look up variables
-                [Token::Identifier(str)] => match str.as_str() {
-                    "x" => 3.0,
-                    "y" => 7.0,
-                    _ => todo!("I don't know the value of the variable {:?}", var),
-                },
-                _ => todo!("I don't know the value of the variable {:?}", var),
-            },
+            Factor::Variable(x) => todo!("I don't know the value of the variable {:?}", x),
             Factor::FunctionCall(call) => todo!("call = {:?}", call),
             Factor::Exponent { base, exponent } => base.eval().powf(exponent.eval()),
             Factor::Root { degree, radicand } => match degree.as_ref().map(|expr| expr.eval()) {

--- a/parser/src/evaluator.rs
+++ b/parser/src/evaluator.rs
@@ -1,5 +1,8 @@
 /// A simple single-threaded evaluator for an AST.
-use crate::ast::{Ast, Factor, MathExpr, Term};
+use crate::{
+    ast::{Ast, Factor, MathExpr, Term},
+    token::Token,
+};
 
 impl Ast {
     pub fn eval(&self) -> f64 {
@@ -32,12 +35,19 @@ impl Factor {
         match self {
             Factor::Constant(c) => *c,
             Factor::Expression(expr) => expr.eval(),
-            Factor::Variable(x) => todo!("I don't know the value of the variable {:?}", x),
+            Factor::Variable(var) => match &var.tokens[..] {
+                // TODO use MathContext to look up variables
+                [Token::Identifier(str)] => match str.as_str() {
+                    "x" => 3.0,
+                    "y" => 7.0,
+                    _ => todo!("I don't know the value of the variable {:?}", var),
+                },
+                _ => todo!("I don't know the value of the variable {:?}", var),
+            },
             Factor::FunctionCall(call) => todo!("call = {:?}", call),
             Factor::Exponent { base, exponent } => base.eval().powf(exponent.eval()),
             Factor::Root { degree, radicand } => match degree.as_ref().map(|expr| expr.eval()) {
-                Some(2.0) | None => radicand.eval().sqrt(),
-                Some(0.0) => 1.0,
+                None => radicand.eval().sqrt(),
                 Some(degree) => radicand.eval().powf(1.0 / degree),
             },
             Factor::Fraction(a, b) => a.eval() / b.eval(),

--- a/parser/src/main.rs
+++ b/parser/src/main.rs
@@ -1,5 +1,6 @@
 use parser::{
-    context::MathContext, lexer::Lexer, normalizer::Normalizer, parser::Parser, token::Token,
+    ast::MathIdentifier, context::MathContext, lexer::Lexer, normalizer::Normalizer,
+    parser::Parser, token::Token,
 };
 use tokio::{
     join,
@@ -57,7 +58,20 @@ impl Prompt {
         let (lexer_in, lexer_out): (Sender<Token>, Receiver<Token>) = mpsc::channel(32);
         let (normalizer_in, normalizer_out): (Sender<Token>, Receiver<Token>) = mpsc::channel(32);
 
-        let context = MathContext::new();
+        let mut context = MathContext::new();
+        context.variables.insert(
+            MathIdentifier {
+                tokens: vec![Token::Identifier("x".to_string())],
+            },
+            3.0,
+        );
+        context.variables.insert(
+            MathIdentifier {
+                tokens: vec![Token::Identifier("y".to_string())],
+            },
+            7.0,
+        );
+
         let lexer = Lexer::new(lexer_in);
         let mut normalizer = Normalizer::new(lexer_out, normalizer_in);
         let mut parser = Parser::new(normalizer_out, context);

--- a/parser/src/main.rs
+++ b/parser/src/main.rs
@@ -1,6 +1,5 @@
 use parser::{
-    ast::MathIdentifier, context::MathContext, lexer::Lexer, normalizer::Normalizer,
-    parser::Parser, token::Token,
+    context::MathContext, lexer::Lexer, normalizer::Normalizer, parser::Parser, token::Token,
 };
 use tokio::{
     join,
@@ -58,20 +57,7 @@ impl Prompt {
         let (lexer_in, lexer_out): (Sender<Token>, Receiver<Token>) = mpsc::channel(32);
         let (normalizer_in, normalizer_out): (Sender<Token>, Receiver<Token>) = mpsc::channel(32);
 
-        let mut context = MathContext::new();
-        context.variables.insert(
-            MathIdentifier {
-                tokens: vec![Token::Identifier("x".to_string())],
-            },
-            3.0,
-        );
-        context.variables.insert(
-            MathIdentifier {
-                tokens: vec![Token::Identifier("y".to_string())],
-            },
-            7.0,
-        );
-
+        let context = MathContext::new();
         let lexer = Lexer::new(lexer_in);
         let mut normalizer = Normalizer::new(lexer_out, normalizer_in);
         let mut parser = Parser::new(normalizer_out, context);
@@ -91,13 +77,14 @@ impl Prompt {
             }
         };
 
+        if self.ast_mode {
+            println!("{:#?}", ast);
+        }
+
         let result = ast.eval();
 
         println!("> {}", result);
 
-        if self.ast_mode {
-            println!("{:#?}", ast);
-        }
         println!();
     }
 }

--- a/parser/src/normalizer.rs
+++ b/parser/src/normalizer.rs
@@ -1,146 +1,63 @@
-use std::{mem::replace, ops::ControlFlow};
-
 use tokio::sync::mpsc::{Receiver, Sender};
 
 use crate::{token::Token, token_reader::TokenReader};
 
 pub struct Normalizer {
-    queue: QueueSender,
+    reader: TokenReader,
+    output: Sender<Token>,
 }
 impl Normalizer {
     pub fn new(input: Receiver<Token>, output: Sender<Token>) -> Self {
         Self {
-            queue: QueueSender {
-                input: TokenReader::new(input),
-                queue: None,
-                output,
-            },
+            reader: TokenReader::new(input),
+            output,
         }
     }
+
     pub async fn normalize(&mut self) {
-        if self.queue.start_read().await.is_break() {
-            return;
-        }
         loop {
-            if self.normalize_tokens().await.is_break() {
-                return;
-            }
-            if self.queue.read_into_queue().await.is_break() {
-                return;
+            self.normalize_tokens().await;
+
+            let token = self.reader.read().await;
+            let eof = token == Token::EndOfContent;
+            self.output.send(token).await.expect("Broken pipe");
+            if eof {
+                break;
             }
         }
     }
-    async fn normalize_tokens(&mut self) -> ControlFlow<()> {
-        match self.queue.get_toks() {
-            (Token::Backslash, Token::Identifier(v)) => match v.as_str() {
+
+    async fn normalize_tokens(&mut self) {
+        match self.reader.peek_range(0..=1).await[..] {
+            [Token::Backslash, Token::Identifier(v)] => match v.as_str() {
                 "cdot" | "cdotp" | "times" => {
-                    return self.queue.replace_queued_with(Token::Asterisk).await
+                    self.reader.replace(0..=1, vec![Token::Asterisk]).await;
                 }
-                "left" | "middle" | "right" => return self.queue.replace_queue().await,
+                "left" | "middle" | "right" => {
+                    self.reader.replace(0..=1, vec![]).await;
+                    // TODO Remove dot after, for example "\left."
+                    // we have no token for lone dots though
+                }
+                "displaystyle" | "textstyle" => {
+                    self.reader.replace(0..=1, vec![]).await;
+                }
                 _ => {}
             },
-            (Token::Caret, Token::NumberLiteral(n)) => {
+            [Token::Caret, Token::NumberLiteral(n)] => {
                 if n.raw.len() == 0 {
                     panic!("string is wierd");
                 }
                 if n.raw.len() != 1 {
                     let mut s = n.raw.clone();
-                    let new2 = Token::NumberLiteral(s.split_off(1).into());
-                    let new1 = Token::NumberLiteral(s.into());
-                    self.queue.replace_second_with(new1);
-                    self.queue.continue_queue_with(new2).await;
+                    let rest = Token::NumberLiteral(s.split_off(1).into());
+                    println!("rest = {:?}", rest);
+                    let single = Token::NumberLiteral(s.into());
+                    println!("single = {:?}", single);
+                    self.reader.replace(1..=1, vec![single, rest]).await;
                 }
             }
             _ => {}
         }
-        ControlFlow::Continue(())
-    }
-}
-
-struct QueueSender {
-    input: TokenReader,
-    queue: Option<[Token; 2]>,
-    output: Sender<Token>,
-}
-impl QueueSender {
-    async fn start_read(&mut self) -> ControlFlow<()> {
-        if self.queue.is_some() {
-            panic!("Started reading while still reading")
-        }
-        let first = self.input.read().await;
-        if first.is_eof() {
-            self.send_or_crash(first).await;
-            return ControlFlow::Break(());
-        }
-        let second = self.input.read().await;
-        if second.is_eof() {
-            self.send_or_crash(first).await;
-            self.send_or_crash(second).await;
-            return ControlFlow::Break(());
-        }
-
-        self.queue = Some([first, second]);
-        ControlFlow::Continue(())
-    }
-    pub async fn replace_queued_with(&mut self, tok: Token) -> ControlFlow<()> {
-        self.move_one_step(tok);
-        let next = self.read().await;
-        if next.is_eof() {
-            self.empty_queue().await;
-            self.send_or_crash(Token::EndOfContent).await;
-            return ControlFlow::Break(());
-        }
-        self.move_one_step(next);
-        ControlFlow::Continue(())
-    }
-    pub async fn replace_queue(&mut self) -> ControlFlow<()> {
-        self.queue = None;
-        self.start_read().await
-    }
-    fn get_queue_or_crash(&mut self) -> &mut [Token; 2] {
-        self.queue.as_mut().expect("the queue was not constructed")
-    }
-    fn get_toks(&mut self) -> (&Token, &Token) {
-        let queue = self.get_queue_or_crash();
-
-        (&queue[0], &queue[1])
-    }
-    pub fn move_one_step(&mut self, token: Token) -> Token {
-        let queue = self.get_queue_or_crash();
-        let temp = replace(&mut queue[1], token);
-        replace(&mut queue[0], temp)
-    }
-    pub async fn read_into_queue(&mut self) -> ControlFlow<()> {
-        let tok = self.input.read().await;
-        let retur = tok.is_eof();
-        let ret = self.move_one_step(tok);
-        self.send_or_crash(ret).await;
-        match retur {
-            true => {
-                self.empty_queue().await;
-                ControlFlow::Break(())
-            }
-            false => ControlFlow::Continue(()),
-        }
-    }
-    pub async fn continue_queue_with(&mut self, next: Token) {
-        let temp = self.move_one_step(next);
-        self.send_or_crash(temp).await;
-    }
-    async fn read(&mut self) -> Token {
-        self.input.read().await
-    }
-    async fn send_or_crash(&self, token: Token) {
-        self.output.send(token).await.expect("Broken Pipe")
-    }
-    async fn empty_queue(&mut self) {
-        let queue = self.queue.take().expect("the queue was not constructed");
-        for t in queue.into_iter() {
-            self.send_or_crash(t).await;
-        }
-    }
-    pub fn replace_second_with(&mut self, token: Token) {
-        self.get_queue_or_crash()[1] = token;
     }
 }
 

--- a/parser/src/token_reader.rs
+++ b/parser/src/token_reader.rs
@@ -19,6 +19,20 @@ impl TokenReader {
         }
     }
 
+    /// Read the next token from the stream, and disregard the "next" queue.
+    async fn read_internal(&mut self) -> Token {
+        if self.eof {
+            return Token::EndOfContent;
+        }
+        let token = self.tokens.recv().await.expect("Broken pipe");
+        // Handle end of file
+        if token == Token::EndOfContent {
+            self.eof = true;
+            return Token::EndOfContent;
+        }
+        return token;
+    }
+
     /// Look at the next token without consuming it.
     ///
     /// Equivalent to `peekn(0)`.
@@ -26,25 +40,31 @@ impl TokenReader {
     /// If end of content is reached, `Token::EndOfContent` will be returned for
     /// subsequent reads.
     pub async fn peek(&mut self) -> &Token {
-        if self.next.len() == 0 {
-            let token = self.read().await;
-            self.next.push_back(token);
-        }
-
-        return &self.next[0];
+        self.peekn(0).await
     }
 
+    /// Look at the token a few steps away from the cursor.
+    ///
+    /// If end of content is reached, `Token::EndOfContent` will be returned for
+    /// subsequent reads.
+    ///
+    /// ## Panics
+    /// If this method is called out of order, for example `peekn(1)`, `peekn(3)`,
+    /// this method will panic since that is usually a sign of a bug.
     pub async fn peekn(&mut self, n: usize) -> &Token {
-        println!("len = {}", self.next.len());
         if self.next.len() == n {
-            let token = self.read().await;
-            println!("pushing");
+            let token = self.read_internal().await;
             self.next.push_back(token);
         } else if self.next.len() < n {
-            panic!("Jump peek detected. This is usually a bug.");
+            panic!(
+                "Jump peek detected. This is usually a bug. \
+                Previous peek: {:?}, this peek: {}",
+                self.next.len().checked_sub(1),
+                n
+            );
         }
 
-        println!("len = {}", self.next.len());
+        // Will never panic since we ensured the queue has enough elements.
         return &self.next[n];
     }
 
@@ -53,21 +73,12 @@ impl TokenReader {
     /// If end of file is reached, `Token::EOF` will be returned for subsequent
     /// reads.
     pub async fn read(&mut self) -> Token {
-        if self.eof {
-            return Token::EndOfContent;
-        }
-        // If we already had it peaked, just consume and return that.
+        // If we already had it peeked, just consume and return that.
         if let Some(token) = self.next.remove(0) {
             return token;
         }
         // Read from channel
-        let token = self.tokens.recv().await.expect("Broken pipe");
-        // Handle end of file
-        if token == Token::EndOfContent {
-            self.eof = true;
-            return Token::EndOfContent;
-        }
-        token
+        self.read_internal().await
     }
 
     /// Consume the next token.
@@ -152,10 +163,56 @@ mod tests {
         assert_eq!(Token::Backslash, reader.peek().await);
         assert_eq!(Token::LeftCurlyBracket, reader.peekn(1).await);
         assert_eq!(Token::Backslash, reader.read().await);
-        assert_eq!(Token::LeftCurlyBracket, reader.peek().await);
+        assert_eq!(Token::LeftCurlyBracket, reader.peekn(0).await);
         assert_eq!(Token::LeftCurlyBracket, reader.read().await);
+        assert_eq!(Token::RightCurlyBracket, reader.peekn(0).await);
+        assert_eq!(Token::RightCurlyBracket, reader.peekn(0).await);
         assert_eq!(Token::RightCurlyBracket, reader.read().await);
         assert_eq!(Token::LeftBracket, reader.read().await);
         assert_eq!(Token::RightBracket, reader.read().await);
+    }
+
+    #[tokio::test]
+    async fn peek_read_end_of_content() {
+        let (tx, rx): (Sender<Token>, Receiver<Token>) = mpsc::channel(32);
+
+        let mut reader = TokenReader::new(rx);
+        tx.send(Token::Plus).await.unwrap();
+        tx.send(Token::EndOfContent).await.unwrap();
+
+        assert_eq!(Token::Plus, reader.read().await);
+        assert_eq!(Token::EndOfContent, reader.read().await);
+        for _ in 0..5 {
+            assert_eq!(Token::EndOfContent, reader.peek().await);
+        }
+        for _ in 0..10 {
+            assert_eq!(Token::EndOfContent, reader.read().await);
+        }
+        for i in 0..10 {
+            assert_eq!(Token::EndOfContent, reader.peekn(i).await);
+        }
+    }
+
+    #[should_panic]
+    #[tokio::test]
+    async fn jump_peek_panic() {
+        let (tx, rx): (Sender<Token>, Receiver<Token>) = mpsc::channel(32);
+
+        let tokens = vec![
+            Token::Backslash,
+            Token::LeftCurlyBracket,
+            Token::RightCurlyBracket,
+            Token::LeftBracket,
+            Token::RightBracket,
+        ];
+
+        let mut reader = TokenReader::new(rx);
+
+        for token in &tokens {
+            tx.send(token.clone()).await.unwrap();
+        }
+
+        assert_eq!(Token::Backslash, reader.peekn(0).await);
+        assert_eq!(Token::RightCurlyBracket, reader.peekn(2).await);
     }
 }


### PR DESCRIPTION
Adds a few functions to `TokenReader`, like `peekn`, `peek_range` and `replace`. These allow the parser to split a single identifier token into characters. The normalizer was also refactored and simplified by reusing these functions.