### PR TITLE
Create MulType enum and pass to Value::mul

### DIFF
--- a/parser/src/approximator.rs
+++ b/parser/src/approximator.rs
@@ -1,7 +1,5 @@
 //! Simple single-threaded Approximator for AST
 
-use crate::ast::MulType;
-
 use super::prelude::*;
 
 /// The errors that can happen when evaluating a AST
@@ -168,7 +166,7 @@ mod tests {
         sync::mpsc::{self},
     };
 
-    use crate::{ast::MulType, prelude::*};
+    use crate::prelude::*;
 
     fn eval_test_from_ast(expected: f64, ast: Ast) {
         let context = MathContext::new();

--- a/parser/src/approximator.rs
+++ b/parser/src/approximator.rs
@@ -81,7 +81,7 @@ impl Approximator {
     fn eval_term(&self, term: &Term) -> Result<Value, EvalError> {
         match term {
             Term::Factor(factor) => self.eval_factor(factor),
-            Term::Multiply(a, b) => {
+            Term::Multiply(_, a, b) => {
                 self.eval_term(a.as_ref())? * self.eval_factor(b)?
             }
             Term::Divide(a, b) => {
@@ -163,7 +163,7 @@ mod tests {
         sync::mpsc::{self},
     };
 
-    use crate::prelude::*;
+    use crate::{ast::MulType, prelude::*};
 
     fn eval_test_from_ast(expected: f64, ast: Ast) {
         let context = MathContext::new();
@@ -221,7 +221,11 @@ mod tests {
             // 2+3*5
             Ast::Expression(MathExpr::Add(
                 Box::new(2.0.into()),
-                Term::Multiply(Box::new(3.0.into()), 5.0.into()),
+                Term::Multiply(
+                    MulType::Asterisk,
+                    Box::new(3.0.into()),
+                    5.0.into(),
+                ),
             )),
         );
     }

--- a/parser/src/approximator.rs
+++ b/parser/src/approximator.rs
@@ -1,4 +1,7 @@
 //! Simple single-threaded Approximator for AST
+
+use crate::ast::MulType;
+
 use super::prelude::*;
 
 /// The errors that can happen when evaluating a AST
@@ -12,6 +15,8 @@ pub enum EvalError {
     IncompatibleMatrixSizes(IncompatibleMatrixSizes),
     /// Could nto fund the value expected
     NotDefined,
+    /// Unclear multiplication type when multiplying matricies.
+    AmbiguousMulType(MulType),
 }
 /// The error for when it required another size of the matrix
 #[derive(Debug)]
@@ -81,9 +86,9 @@ impl Approximator {
     fn eval_term(&self, term: &Term) -> Result<Value, EvalError> {
         match term {
             Term::Factor(factor) => self.eval_factor(factor),
-            Term::Multiply(_, a, b) => {
-                self.eval_term(a.as_ref())? * self.eval_factor(b)?
-            }
+            Term::Multiply(mul_type, a, b) => self
+                .eval_term(a.as_ref())?
+                .mul(mul_type, self.eval_factor(b)?),
             Term::Divide(a, b) => {
                 self.eval_term(a.as_ref())? / self.eval_factor(b)?
             }

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -97,14 +97,29 @@ impl From<MathIdentifier> for MathExpr {
 
 /// The type of multiplication.
 ///
-/// For most operands, this makes no difference, but in some cases, for example
-/// when multiplying vectors, the symbol used for multiplication makes a
-/// difference.
+/// For scalar multiplication, the type of multiplication makes no difference,
+/// but in some cases, for example when multiplying vectors, the symbol used
+/// for multiplication makes a difference.
 #[derive(PartialEq, Debug, Clone)]
 pub enum MulType {
+    /// 2 * x
+    ///
+    /// Not defined when used on matrices.
     Asterisk,
+
+    /// 2 \cdot x
+    ///
+    /// Dot product when used on matrices (vectors).
     Cdot,
+
+    /// 2 \times x
+    ///
+    /// Cross product when used on matrices (vectors).
     Times,
+
+    /// 2x
+    ///
+    /// Matrix multiplication when used on matrices.
     Implicit,
 }
 

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -95,6 +95,19 @@ impl From<MathIdentifier> for MathExpr {
     }
 }
 
+/// The type of multiplication.
+///
+/// For most operands, this makes no difference, but in some cases, for example
+/// when multiplying vectors, the symbol used for multiplication makes a
+/// difference.
+#[derive(PartialEq, Debug, Clone)]
+pub enum MulType {
+    Asterisk,
+    Cdot,
+    Times,
+    Implicit,
+}
+
 /// A term consists of a number or variable, or the product or quotient of
 /// multiple numbers and variables.
 ///
@@ -125,6 +138,7 @@ pub enum Term {
     ///     parse("2*2", &context),
     ///     Ast::Expression(
     ///         Term::Multiply(
+    ///             MulType::Asterisk,
     ///             Box::new(Term::Factor(
     ///                 Factor::Constant(2.0)
     ///             )),
@@ -133,7 +147,7 @@ pub enum Term {
     ///     )
     /// );
     /// ```
-    Multiply(Box<Term>, Factor),
+    Multiply(MulType, Box<Term>, Factor),
 
     /// Division between a Term and Factor.
     /// ## Examples

--- a/parser/src/matrix.rs
+++ b/parser/src/matrix.rs
@@ -1,7 +1,7 @@
 //!
 use std::ops::{Add, AddAssign, Mul, Sub};
 
-use crate::{ast::MulType, prelude::*};
+use crate::prelude::*;
 
 #[derive(PartialEq, Debug)]
 

--- a/parser/src/matrix.rs
+++ b/parser/src/matrix.rs
@@ -1,7 +1,7 @@
 //!
 use std::ops::{Add, AddAssign, Mul, Sub};
 
-use crate::prelude::*;
+use crate::{ast::MulType, prelude::*};
 
 #[derive(PartialEq, Debug)]
 
@@ -356,10 +356,11 @@ impl Matrix<MathExpr> {
     }
 }
 
-impl Mul<Matrix<Value>> for Matrix<Value> {
-    type Output = Result<Matrix<Value>, EvalError>;
-
-    fn mul(self, rhs: Matrix<Value>) -> Self::Output {
+impl Matrix<Value> {
+    pub fn matrix_mul(
+        self,
+        rhs: Matrix<Value>,
+    ) -> Result<Matrix<Value>, EvalError> {
         if self.column_count != rhs.row_count {
             return Err(IncompatibleMatrixSizes::Row {
                 expected: self.column_count,
@@ -379,7 +380,7 @@ impl Mul<Matrix<Value>> for Matrix<Value> {
                 for k in 0..self.column_count {
                     let a = self.get(i, k).clone();
                     let b = rhs.get(k, j).clone();
-                    let term = (a * b)?;
+                    let term = (a.mul(&MulType::Implicit, b))?;
                     sum = Some(match sum {
                         Some(prev) => (prev + term)?,
                         None => term,
@@ -518,7 +519,7 @@ mod tests {
         c.set(1, 0, Value::Scalar(43.0));
         c.set(1, 1, Value::Scalar(50.0));
 
-        assert_eq!((a * b).unwrap(), c);
+        assert_eq!((a.matrix_mul(b)).unwrap(), c);
     }
 
     #[test]
@@ -538,6 +539,6 @@ mod tests {
         c.set(1, 0, Value::Scalar(53.0));
         c.set(2, 0, Value::Scalar(83.0));
 
-        assert_eq!((a * b).unwrap(), c);
+        assert_eq!((a.matrix_mul(b)).unwrap(), c);
     }
 }

--- a/parser/src/normalizer.rs
+++ b/parser/src/normalizer.rs
@@ -44,9 +44,6 @@ impl Normalizer {
             [Token::Backslash, Token::Identifier(v)] => {
                 trace!("ident = {v}");
                 match v.as_str() {
-                    "cdot" | "cdotp" | "times" => {
-                        self.reader.replace(0..=1, vec![Token::Asterisk]).await;
-                    }
                     "left" | "middle" | "right" => {
                         self.reader.replace(0..=1, vec![]).await;
                         // TODO Remove dot after, for example "\left."
@@ -158,66 +155,6 @@ mod tests {
                 Token::Caret,
                 Token::NumberLiteral("0".to_owned().into()),
                 Token::NumberLiteral("25".to_owned().into()),
-                Token::EndOfContent,
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn replace_cdot_with_asterisk() {
-        assert_eq!(
-            normalize(vec![
-                Token::NumberLiteral("1".to_owned().into()),
-                Token::Backslash,
-                Token::Identifier("cdot".to_string()),
-                Token::NumberLiteral("1".to_owned().into()),
-                Token::EndOfContent,
-            ])
-            .await,
-            vec![
-                Token::NumberLiteral("1".to_owned().into()),
-                Token::Asterisk,
-                Token::NumberLiteral("1".to_owned().into()),
-                Token::EndOfContent,
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn replace_cdotp_with_asterisk() {
-        assert_eq!(
-            normalize(vec![
-                Token::NumberLiteral("1".to_owned().into()),
-                Token::Backslash,
-                Token::Identifier("cdotp".to_string()),
-                Token::NumberLiteral("1".to_owned().into()),
-                Token::EndOfContent,
-            ])
-            .await,
-            vec![
-                Token::NumberLiteral("1".to_owned().into()),
-                Token::Asterisk,
-                Token::NumberLiteral("1".to_owned().into()),
-                Token::EndOfContent,
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn replace_times_with_asterisk() {
-        assert_eq!(
-            normalize(vec![
-                Token::NumberLiteral("1".to_owned().into()),
-                Token::Backslash,
-                Token::Identifier("times".to_string()),
-                Token::NumberLiteral("1".to_owned().into()),
-                Token::EndOfContent,
-            ])
-            .await,
-            vec![
-                Token::NumberLiteral("1".to_owned().into()),
-                Token::Asterisk,
-                Token::NumberLiteral("1".to_owned().into()),
                 Token::EndOfContent,
             ]
         );

--- a/parser/src/parsing.rs
+++ b/parser/src/parsing.rs
@@ -1,6 +1,6 @@
 use tracing::{trace, trace_span};
 
-use crate::{ast::MulType, prelude::*};
+use crate::prelude::*;
 use async_recursion::async_recursion;
 
 pub struct Parser {
@@ -490,7 +490,7 @@ mod tests {
         sync::mpsc::{self},
     };
 
-    use crate::{ast::MulType, prelude::*};
+    use crate::prelude::*;
 
     async fn parse_test(text: &str, expected_ast: Ast) {
         let (lexer_in, lexer_out): (TokenSender, TokenReceiver) =

--- a/parser/src/prelude.rs
+++ b/parser/src/prelude.rs
@@ -23,7 +23,7 @@ pub(crate) type TokenSender = Sender<Token>;
 pub(crate) use crate::{
     approximator::EvalError,
     approximator::IncompatibleMatrixSizes,
-    ast::{Factor, FunctionCall, MathExpr, MathIdentifier, Term},
+    ast::{Factor, FunctionCall, MathExpr, MathIdentifier, MulType, Term},
     lexer::Lexer,
     matrix::Matrix,
     normalizer::Normalizer,
@@ -153,7 +153,7 @@ where
 }
 #[cfg(test)]
 mod tests {
-    use crate::{ast::MulType, prelude::*};
+    use crate::prelude::*;
 
     async fn parse_test(text: &str, expected_ast: Ast) {
         let found_ast =

--- a/parser/src/prelude.rs
+++ b/parser/src/prelude.rs
@@ -153,7 +153,7 @@ where
 }
 #[cfg(test)]
 mod tests {
-    use crate::prelude::*;
+    use crate::{ast::MulType, prelude::*};
 
     async fn parse_test(text: &str, expected_ast: Ast) {
         let found_ast =
@@ -191,6 +191,7 @@ mod tests {
                     3f64.into(),
                 )),
                 Term::Multiply(
+                    MulType::Asterisk,
                     Box::new(Term::Factor(Factor::Parenthesis(Box::new(
                         MathExpr::Add(Box::new(4f64.into()), 5f64.into()),
                     )))),
@@ -275,6 +276,7 @@ mod tests {
         parse_test(
             "2^025", // this is 2^0 * 25
             Ast::Expression(MathExpr::Term(Term::Multiply(
+                MulType::Implicit,
                 //2^0
                 Box::new(Term::Factor(Factor::Power {
                     base: Box::new(Factor::Constant(2.0)),
@@ -294,6 +296,7 @@ mod tests {
         parse_test(
             "2(3)^3",
             Ast::Expression(MathExpr::Term(Term::Multiply(
+                MulType::Implicit,
                 // 2
                 Box::new(2f64.into()),
                 // (3)^3
@@ -313,6 +316,7 @@ mod tests {
             Ast::Expression(MathExpr::Add(
                 // 2x^{2}
                 Box::new(MathExpr::Term(Term::Multiply(
+                    MulType::Implicit,
                     // 2
                     Box::new(Term::Factor(Factor::Constant(2.0))),
                     // x^{2}
@@ -327,8 +331,10 @@ mod tests {
                 ))),
                 // 5xy
                 Term::Multiply(
+                    MulType::Implicit,
                     // 5x
                     Box::new(Term::Multiply(
+                        MulType::Implicit,
                         // 5
                         Box::new(5f64.into()),
                         // x
@@ -351,8 +357,10 @@ mod tests {
         parse_test(
             "2xy^2",
             Ast::Expression(MathExpr::Term(Term::Multiply(
+                MulType::Implicit,
                 // 2x
                 Box::new(Term::Multiply(
+                    MulType::Implicit,
                     // 2
                     Box::new(2f64.into()),
                     // x
@@ -393,8 +401,10 @@ mod tests {
         parse_test(
             "\\pi(x)\\ln(x)", // this is pi * x * ln(x)
             Ast::Expression(MathExpr::Term(Term::Multiply(
+                MulType::Implicit,
                 // \pi(x)
                 Box::new(Term::Multiply(
+                    MulType::Implicit,
                     Box::new(
                         Factor::Variable(MathIdentifier {
                             tokens: vec![
@@ -438,6 +448,7 @@ mod tests {
             Ast::Expression(MathExpr::Add(
                 // 5/2x
                 Box::new(MathExpr::Term(Term::Multiply(
+                    MulType::Implicit,
                     // 5/2
                     Box::new(Term::Divide(
                         // 5
@@ -472,6 +483,7 @@ mod tests {
             "|-3|",
             Ast::Expression(
                 Factor::Abs(Box::new(MathExpr::Term(Term::Multiply(
+                    MulType::Implicit,
                     Box::new((-1f64).into()),
                     3f64.into(),
                 ))))

--- a/repl/src/main.rs
+++ b/repl/src/main.rs
@@ -144,6 +144,7 @@ impl Repl {
     }
     fn ast_equality(&mut self, lhs: MathExpr, rhs: MathExpr) -> String {
         if let MathExpr::Term(Term::Multiply(
+            ast::MulType::Implicit,
             var,
             Factor::Parenthesis(possible_args),
         )) = lhs


### PR DESCRIPTION
We can now differentiate matrix multiplication, dot product, and cross product.