### PR TITLE
Implement dot product and cross product in approximator

### DIFF
--- a/parser/src/approximator.rs
+++ b/parser/src/approximator.rs
@@ -48,7 +48,7 @@ impl Approximator {
             Term::Factor(factor) => self.eval_factor(factor),
             Term::Multiply(mul_type, a, b) => self
                 .eval_term(a.as_ref())?
-                .mul(mul_type, self.eval_factor(b)?),
+                .mul(mul_type, &self.eval_factor(b)?),
             Term::Divide(a, b) => {
                 self.eval_term(a.as_ref())? / self.eval_factor(b)?
             }

--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -72,6 +72,11 @@ pub enum IncompatibleMatrixSizes {
         /// The value found
         found: usize,
     },
+    #[snafu(display("Cross product can only be used on vectors with 3 components, got {found_size:?}"))]
+    CrossProduct {
+        /// The found size of the vector.
+        found_size: usize,
+    },
     #[snafu(display(
         "Expected a vector but got a {rows:?}x{columns:?} matrix."
     ))]

--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -20,6 +20,8 @@ pub enum ParseError {
     InvalidBegin { beginning: String },
     #[snafu(display("Expected it to have the same amount of columns, but previous had:{prev} instead got:{current}"))]
     MismatchedMatrixColumnSize { prev: usize, current: usize },
+    #[snafu(display("A matrix cannot be empty."))]
+    EmptyMatrix,
 }
 #[derive(Debug, Snafu)]
 pub enum AstError {
@@ -54,6 +56,8 @@ pub enum EvalError {
 /// The error for when it required another size of the matrix
 #[derive(Debug, Snafu)]
 pub enum IncompatibleMatrixSizes {
+    // TODO I don't like how we say that something is "expected" here. We can't say
+    // something is expected, we just know that they are incompatible. /Alvin
     #[snafu(display("Expected row {expected:?} found {found:?}"))]
     Row {
         /// The expected value for the matrix
@@ -68,4 +72,12 @@ pub enum IncompatibleMatrixSizes {
         /// The value found
         found: usize,
     },
+    #[snafu(display(
+        "Expected a vector but got a {rows:?}x{columns:?} matrix."
+    ))]
+    Vector { rows: usize, columns: usize },
+    #[snafu(display(
+        "Vectors must be of the same size, but got {a:?} and {b:?}"
+    ))]
+    SameSizeVectors { a: usize, b: usize },
 }

--- a/parser/src/matrix.rs
+++ b/parser/src/matrix.rs
@@ -21,6 +21,8 @@ impl<T> Matrix<T> {
     /// `row_count * column_count`. This ensures data consistency within the
     /// matrix and prevents potential errors later due to an incorrect
     /// underlying representation.
+    ///
+    /// Will also panic if the Matrix has a row or column count of zero.
     pub fn new(values: Vec<T>, row_count: usize, column_count: usize) -> Self {
         if values.len() != row_count * column_count {
             panic!(
@@ -34,6 +36,9 @@ impl<T> Matrix<T> {
             // here but i think we want that as a result No I think
             // it should be a panic. If this is called with an incorrect vec
             // that is a bug that we need to fix.
+        }
+        if row_count == 0 || column_count == 0 {
+            panic!("Empty matrix.");
         }
         Self {
             values,
@@ -87,6 +92,50 @@ impl<T> Matrix<T> {
     pub fn column_count(&self) -> usize {
         self.column_count
     }
+
+    /// Returns whether this matrix is a vector. (Could be a row vector
+    /// or a column vector).
+    pub fn is_vector(&self) -> bool {
+        return self.is_row_vector() || self.is_column_vector();
+    }
+
+    /// Returns whether this matrix is a row vector.
+    pub fn is_row_vector(&self) -> bool {
+        return self.row_count == 1;
+    }
+
+    /// Returns whether this matrix is a column vector.
+    pub fn is_column_vector(&self) -> bool {
+        return self.column_count == 1;
+    }
+
+    /// Get the amount of elements this vector has.
+    ///
+    /// ## Panics
+    /// Panics if this matrix is not a vector.
+    pub fn get_vector_size(&self) -> usize {
+        if self.is_row_vector() {
+            return self.column_count;
+        }
+        if self.is_column_vector() {
+            return self.row_count;
+        }
+        panic!("Not a vector.");
+    }
+
+    /// Get the elements at an index in this vector.
+    ///
+    /// ## Panics
+    /// Panics if this matrix is not a vector.
+    pub fn get_vector_element(&self, index: usize) -> &T {
+        if self.is_row_vector() {
+            return self.get(0, index);
+        }
+        if self.is_column_vector() {
+            return self.get(index, 0);
+        }
+        panic!("Not a vector.");
+    }
 }
 
 impl<T: Clone> Matrix<T> {
@@ -126,7 +175,60 @@ impl<T: Clone> Matrix<T> {
         }
     }
 }
+
+impl Matrix<Value> {
+    /// Calculates the dot product of two matrices (treated as vectors).
+    ///
+    /// # Errors
+    /// Returns an `Err` if:
+    /// - One of the matricies isn't a vector.
+    /// - The vectors do not have the same size.
+    pub fn dot_product(
+        &self,
+        other: &Matrix<Value>,
+    ) -> Result<Value, EvalError> {
+        // Validation
+        fn vector_err(m: &Matrix<Value>) -> EvalError {
+            return EvalError::IncompatibleMatrixSizes {
+                source: IncompatibleMatrixSizes::Vector {
+                    rows: m.row_count(),
+                    columns: m.column_count(),
+                },
+            };
+        }
+
+        if !self.is_vector() {
+            return Err(vector_err(self));
+        }
+        if !other.is_vector() {
+            return Err(vector_err(other));
+        }
+        if self.get_vector_size() != other.get_vector_size() {
+            return Err(EvalError::IncompatibleMatrixSizes {
+                source: IncompatibleMatrixSizes::SameSizeVectors {
+                    a: self.get_vector_size(),
+                    b: other.get_vector_size(),
+                },
+            });
+        }
+
+        // Calculation
+        let mut sum = Option::None;
+        for i in 0..self.get_vector_size() {
+            let a_i = self.get_vector_element(i);
+            let b_i = other.get_vector_element(i);
+            let term = a_i.mul(&MulType::Implicit, b_i)?;
+            sum = Some(match sum {
+                Some(sum) => (sum + term)?,
+                None => term,
+            });
+        }
+        Ok(sum.expect("Empty vector"))
+    }
+}
+
 impl<Lhs> Matrix<Lhs> {
+    /*
     /// Calculates the dot product of two matrices (treated as vectors).
     ///
     /// # Errors
@@ -158,6 +260,8 @@ impl<Lhs> Matrix<Lhs> {
 
         Ok(result)
     }
+    */
+
     /// Calculates the cross product of two 3D vectors represented as matrices.
     ///
     /// # Errors
@@ -359,8 +463,8 @@ impl Matrix<MathExpr> {
 
 impl Matrix<Value> {
     pub fn matrix_mul(
-        self,
-        rhs: Matrix<Value>,
+        &self,
+        rhs: &Matrix<Value>,
     ) -> Result<Matrix<Value>, EvalError> {
         if self.column_count != rhs.row_count {
             return Err(IncompatibleMatrixSizes::Row {
@@ -379,8 +483,8 @@ impl Matrix<Value> {
             for j in 0..rhs.column_count {
                 let mut sum = Option::None;
                 for k in 0..self.column_count {
-                    let a = self.get(i, k).clone();
-                    let b = rhs.get(k, j).clone();
+                    let a = self.get(i, k);
+                    let b = rhs.get(k, j);
                     let term = (a.mul(&MulType::Implicit, b))?;
                     sum = Some(match sum {
                         Some(prev) => (prev + term)?,
@@ -468,14 +572,12 @@ impl<Lhs: Clone + Mul<Value, Output = Result<Value, EvalError>>> Mul<Value>
         self.map(|val| val.clone() * rhs.clone())
     }
 }
-impl<Lhs: Clone + Mul<f64, Output = Result<Value, EvalError>>> Mul<f64>
-    for Matrix<Lhs>
-{
+impl Mul<f64> for &Matrix<Value> {
     type Output = Result<Matrix<Value>, EvalError>;
 
     fn mul(self, rhs: f64) -> Self::Output {
         // Multiply matrix components by self
-        self.map(|val| val.clone() * rhs)
+        self.map(|val| val * rhs)
     }
 }
 
@@ -520,7 +622,7 @@ mod tests {
         c.set(1, 0, Value::Scalar(43.0));
         c.set(1, 1, Value::Scalar(50.0));
 
-        assert_eq!((a.matrix_mul(b)).unwrap(), c);
+        assert_eq!((a.matrix_mul(&b)).unwrap(), c);
     }
 
     #[test]
@@ -540,6 +642,51 @@ mod tests {
         c.set(1, 0, Value::Scalar(53.0));
         c.set(2, 0, Value::Scalar(83.0));
 
-        assert_eq!((a.matrix_mul(b)).unwrap(), c);
+        assert_eq!((a.matrix_mul(&b)).unwrap(), c);
+    }
+
+    #[test]
+    fn dot_product_row_column_vectors() {
+        let mut a = Matrix::new_default(1, 3, Value::Scalar(0.0));
+        a.set(0, 0, Value::Scalar(1.0));
+        a.set(0, 1, Value::Scalar(2.0));
+        a.set(0, 2, Value::Scalar(3.0));
+        let mut b = Matrix::new_default(3, 1, Value::Scalar(0.0));
+        b.set(0, 0, Value::Scalar(4.0));
+        b.set(1, 0, Value::Scalar(5.0));
+        b.set(2, 0, Value::Scalar(6.0));
+
+        assert_eq!(a.dot_product(&b).unwrap(), Value::Scalar(32.0));
+        assert_eq!(b.dot_product(&a).unwrap(), Value::Scalar(32.0));
+    }
+
+    #[test]
+    fn dot_product_row_vectors() {
+        let mut a = Matrix::new_default(1, 3, Value::Scalar(0.0));
+        a.set(0, 0, Value::Scalar(1.0));
+        a.set(0, 1, Value::Scalar(2.0));
+        a.set(0, 2, Value::Scalar(3.0));
+        let mut b = Matrix::new_default(1, 3, Value::Scalar(0.0));
+        b.set(0, 1, Value::Scalar(5.0));
+        b.set(0, 0, Value::Scalar(4.0));
+        b.set(0, 2, Value::Scalar(6.0));
+
+        assert_eq!(a.dot_product(&b).unwrap(), Value::Scalar(32.0));
+        assert_eq!(b.dot_product(&a).unwrap(), Value::Scalar(32.0));
+    }
+
+    #[test]
+    fn dot_product_column_vectors() {
+        let mut a = Matrix::new_default(3, 1, Value::Scalar(0.0));
+        a.set(0, 0, Value::Scalar(1.0));
+        a.set(1, 0, Value::Scalar(2.0));
+        a.set(2, 0, Value::Scalar(3.0));
+        let mut b = Matrix::new_default(3, 1, Value::Scalar(0.0));
+        b.set(0, 0, Value::Scalar(4.0));
+        b.set(1, 0, Value::Scalar(5.0));
+        b.set(2, 0, Value::Scalar(6.0));
+
+        assert_eq!(a.dot_product(&b).unwrap(), Value::Scalar(32.0));
+        assert_eq!(b.dot_product(&a).unwrap(), Value::Scalar(32.0));
     }
 }

--- a/parser/src/parsing.rs
+++ b/parser/src/parsing.rs
@@ -479,6 +479,10 @@ impl Parser {
             }
         }
 
+        if row_count == 0 || column_count == 0 {
+            return Err(ParseError::EmptyMatrix);
+        }
+
         Ok(Matrix::new(values, row_count, column_count))
     }
 }

--- a/parser/src/value.rs
+++ b/parser/src/value.rs
@@ -15,7 +15,13 @@ impl Value {
     pub fn scalar(&self) -> Result<f64, EvalError> {
         match self {
             Value::Scalar(val) => Ok(*val),
-            Value::Matrix(_) => Err(EvalError::ExpectedScalar),
+            Value::Matrix(m) => {
+                // Treat a 1x1 matrix as a scalar.
+                if m.row_count() == 1 && m.column_count() == 1 {
+                    return m.get(0, 0).scalar();
+                }
+                Err(EvalError::ExpectedScalar)
+            }
         }
     }
     pub fn map_expecting_scalar(
@@ -80,15 +86,15 @@ impl Sub for Value {
 
 impl Value {
     pub fn mul(
-        self,
+        &self,
         mul_type: &MulType,
-        rhs: Self,
+        rhs: &Self,
     ) -> Result<Value, EvalError> {
         Ok(match (self, rhs) {
             (Value::Scalar(a), Value::Scalar(b)) => Value::Scalar(a * b),
             (Value::Matrix(a), Value::Matrix(b)) => match mul_type {
-                MulType::Implicit => Value::Matrix((a.matrix_mul(b))?),
-                MulType::Cdot => todo!("a.dot_product(b)"),
+                MulType::Implicit => Value::Matrix((a.matrix_mul(&b))?),
+                MulType::Cdot => a.dot_product(&b)?,
                 MulType::Times => todo!("a.cross_product(b)"),
                 _ => {
                     return Err(EvalError::AmbiguousMulType {
@@ -97,10 +103,10 @@ impl Value {
                 }
             },
             (Value::Scalar(scalar), Value::Matrix(matrix)) => {
-                Value::Matrix((matrix * scalar)?)
+                Value::Matrix((matrix.mul(*scalar))?)
             }
             (Value::Matrix(matrix), Value::Scalar(scalar)) => {
-                Value::Matrix((matrix * scalar)?)
+                Value::Matrix((matrix * *scalar)?)
             }
         })
     }
@@ -119,7 +125,7 @@ impl Div for Value {
     }
 }
 
-impl Mul<f64> for Value {
+impl Mul<f64> for &Value {
     type Output = Result<Value, EvalError>;
 
     fn mul(self, rhs: f64) -> Self::Output {

--- a/parser/src/value.rs
+++ b/parser/src/value.rs
@@ -95,7 +95,7 @@ impl Value {
             (Value::Matrix(a), Value::Matrix(b)) => match mul_type {
                 MulType::Implicit => Value::Matrix((a.matrix_mul(&b))?),
                 MulType::Cdot => a.dot_product(&b)?,
-                MulType::Times => todo!("a.cross_product(b)"),
+                MulType::Times => Value::Matrix(a.cross_product(&b)?),
                 _ => {
                     return Err(EvalError::AmbiguousMulType {
                         r#type: mul_type.clone(),


### PR DESCRIPTION
Changes some Mul implementations to use references instead of moving the type.

Unfortunately uncomments the generic versions of `dot_product` and `cross_product` since they do not work with `Value`s since their addition and multiplication returns a `Result`, and multiplication needs a `MulType`. Currently, I don't think we need this to be generic since `Value` is the only type it's used for. But it might be nice to have sometime in the future when we want to implement a CAS that uses different data types other than `Value`.